### PR TITLE
Fixes #22543 following upstream instructions

### DIFF
--- a/Formula/helm.rb
+++ b/Formula/helm.rb
@@ -17,6 +17,7 @@ class Helm < Formula
   depends_on "go" => :build
 
   def install
+    system "go", "mod", "tidy"
     system "make", "build"
     bin.install "bin/helm"
 


### PR DESCRIPTION
This just follows what was done by upstream according to helm/helm#9486

I didn't bump version because anyone affected that didn't fix for themselves will still need to upgrade to this version and unaffected (probably macos) users don't need to install again.

Test, audit, and style all came out clean.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
Plenty of info about the build failure in #22543